### PR TITLE
Add ".test-mojom" in package.json

### DIFF
--- a/vscode-mojom/package.json
+++ b/vscode-mojom/package.json
@@ -29,7 +29,8 @@
       {
         "id": "mojom",
         "extensions": [
-          ".mojom"
+          ".mojom",
+          ".test-mojom"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
In crbug.com/397343888, a chromium dev requested support  for formatting .test-mojom files.

This patch adds .test-mojom in package.json such that they are classified as mojom language files in VSCode and Cider